### PR TITLE
Accept any prefix and suffix of the version string in GitHub release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,16 @@
 [![GitHub Action Marketplace](https://img.shields.io/badge/GitHub%20Action-Marketplace-red)](https://github.com/marketplace/actions/upload-microsoft-store-msix-package-to-github-release)
 [![GitHub Release](https://img.shields.io/github/v/release/JasonWei512/Upload-Microsoft-Store-MSIX-Package-to-GitHub-Release?label=Release)](https://github.com/JasonWei512/Upload-Microsoft-Store-MSIX-Package-to-GitHub-Release/releases/latest)
 
-A GitHub action to download the latest MSIX packages from Microsoft Store and upload them to an **existing** GitHub release with corresponding tag. 
+A GitHub action to download the latest MSIX packages from Microsoft Store and upload them to an **existing** GitHub release with the same version tag. 
 
-For example, if the latest Microsoft Store package version is `1.2.3.0`, it will upload MSIX packges to a GitHub release with one of the following tags:
+The GitHub release tag name should contain at least 3 digits, like `x.y.z`.
 
-- `1.2.3.0`
+For example, if the latest Microsoft Store package version is `1.2.3.0`, it will upload MSIX packges to the GitHub release with a tag like:
+
 - `1.2.3`
-- `v1.2.3.0`
-- `v1.2.3`
+- `1.2.3.0`
+- `v1.2.3.dev`
+- `Version-1.2.3.0-preview`
 
 
 # Quick Start

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 [![GitHub Action Marketplace](https://img.shields.io/badge/GitHub%20Action-Marketplace-red)](https://github.com/marketplace/actions/upload-microsoft-store-msix-package-to-github-release)
 [![GitHub Release](https://img.shields.io/github/v/release/JasonWei512/Upload-Microsoft-Store-MSIX-Package-to-GitHub-Release?label=Release)](https://github.com/JasonWei512/Upload-Microsoft-Store-MSIX-Package-to-GitHub-Release/releases/latest)
 
-A GitHub action to download the latest MSIX packages from Microsoft Store and upload them to an **existing** GitHub release with the same version tag. 
+A GitHub action to download the latest MSIX packages from Microsoft Store and upload them to an **existing** GitHub release with corresponding version tag. 
 
-The GitHub release tag name should contain at least 3 digits, like `x.y.z`.
+The GitHub release tag should contain at least 3 digits, in the format of `x.y.z`.
 
-For example, if the latest Microsoft Store package version is `1.2.3.0`, it will upload MSIX packges to the GitHub release with a tag like:
+For example, if the latest Microsoft Store package version is `1.2.3.0`, it will upload MSIX packages to the GitHub release whose tag contains `1.2.3`, such as:
 
 - `1.2.3`
 - `1.2.3.0`
 - `v1.2.3.dev`
-- `Version-1.2.3.0-preview`
+- `Version-1.2.3.0-Preview`
 
 
 # Quick Start

--- a/UploadMicrosoftStoreMsixPackageToGitHubRelease.Test/UnitTest.cs
+++ b/UploadMicrosoftStoreMsixPackageToGitHubRelease.Test/UnitTest.cs
@@ -6,7 +6,7 @@ public class UnitTest
     [MemberData(nameof(TestData_CommonHelper_MsixPackageAndGitHubReleaseVersionsAreEqual_True))]
     public void CommonHelper_MsixPackageAndGitHubReleaseVersionsAreEqual_True(Version msixPackageVersion, string gitHubReleaseTagName)
     {
-        Assert.True(CommonHelper.MsixPackageAndGitHubReleaseVersionsAreEqual(msixPackageVersion, gitHubReleaseTagName));
+        Assert.True(VersionComparer.MsixPackageAndGitHubReleaseVersionsAreEqual(msixPackageVersion, gitHubReleaseTagName));
     }
 
     public static TheoryData<Version, string> TestData_CommonHelper_MsixPackageAndGitHubReleaseVersionsAreEqual_True => new()
@@ -26,7 +26,7 @@ public class UnitTest
     [MemberData(nameof(TestData_CommonHelper_MsixPackageAndGitHubReleaseVersionsAreEqual_False))]
     public void CommonHelper_MsixPackageAndGitHubReleaseVersionsAreEqual_False(Version msixPackageVersion, string gitHubReleaseTagName)
     {
-        Assert.False(CommonHelper.MsixPackageAndGitHubReleaseVersionsAreEqual(msixPackageVersion, gitHubReleaseTagName));
+        Assert.False(VersionComparer.MsixPackageAndGitHubReleaseVersionsAreEqual(msixPackageVersion, gitHubReleaseTagName));
     }
 
     public static TheoryData<Version, string> TestData_CommonHelper_MsixPackageAndGitHubReleaseVersionsAreEqual_False => new()

--- a/UploadMicrosoftStoreMsixPackageToGitHubRelease/CommonHelper.cs
+++ b/UploadMicrosoftStoreMsixPackageToGitHubRelease/CommonHelper.cs
@@ -1,33 +1,33 @@
+using System.Text.RegularExpressions;
+
 namespace UploadMicrosoftStoreMsixPackageToGitHubRelease;
 
-public static class CommonHelper
+public static partial class CommonHelper
 {
     /// <summary>
-    /// Only compares the first 3 digits and ignores the "v" prefix in GitHub tag name. <br/>
-    /// Example: <paramref name="msixPackageVersion"/> "1.2.3.4" is equal to <paramref name="gitHubReleaseTagName"/> "v1.2.3".
+    /// A regex that matches a version string with 3 digits like "1.2.3".
     /// </summary>
-    /// <param name="msixPackageVersion">Have 4 digits. Example: "1.2.3.4"</param>
-    /// <param name="gitHubReleaseTagName">Can have a "v" prefix. Can contain 3 or 4 digits. Example: "v1.2.3"</param>
+    [GeneratedRegex(@"\d+\.\d+\.\d+")]
+    private static partial Regex VersionRegex();
+
+    /// <summary>
+    /// Only compares the first 3 digits of <paramref name="msixPackageVersion"/> and <paramref name="gitHubReleaseTagName"/>. <br/>
+    /// Example: <paramref name="msixPackageVersion"/> "1.2.3.4" is equal to <paramref name="gitHubReleaseTagName"/> "v1.2.3-preview".
+    /// </summary>
+    /// <param name="msixPackageVersion">A version containing 4 digits. Example: "1.2.3.4"</param>
+    /// <param name="gitHubReleaseTagName">A valid version string should contain at least 3 digits. Example: "v1.2.3-preview"</param>
     public static bool MsixPackageAndGitHubReleaseVersionsAreEqual(Version msixPackageVersion, string gitHubReleaseTagName)
     {
-        string gitHubReleaseVersionString = new(gitHubReleaseTagName);
-        if (gitHubReleaseVersionString.StartsWith("v") || gitHubReleaseVersionString.StartsWith("V"))
+        Match versionRegexMatch = VersionRegex().Match(gitHubReleaseTagName);
+        if (!versionRegexMatch.Success)
         {
-            gitHubReleaseVersionString = gitHubReleaseVersionString[1..];
-        }
-        if (gitHubReleaseVersionString.EndsWith(".dev"))
-        {
-            gitHubReleaseVersionString = gitHubReleaseVersionString.Replace(".dev", "");
-        }
-        else if (gitHubReleaseVersionString.Contains(".dev"))
-        {
-            gitHubReleaseVersionString = gitHubReleaseVersionString.Replace(".dev", ".");
+            return false;
         }
 
         Version gitHubReleaseVersion;
         try
         {
-            gitHubReleaseVersion = new Version(gitHubReleaseVersionString);
+            gitHubReleaseVersion = new Version(versionRegexMatch.Value);
         }
         catch
         {

--- a/UploadMicrosoftStoreMsixPackageToGitHubRelease/GitHubHelper.cs
+++ b/UploadMicrosoftStoreMsixPackageToGitHubRelease/GitHubHelper.cs
@@ -24,7 +24,7 @@ public class GitHubHelper
         {
             if (await releases.GetLatest(gitHubRepoOwner, gitHubRepoName) is Release latestGitHubRelease)   // Might throw exception if not found
             {
-                if (CommonHelper.MsixPackageAndGitHubReleaseVersionsAreEqual(msixPackageVersion, latestGitHubRelease.TagName))
+                if (VersionComparer.MsixPackageAndGitHubReleaseVersionsAreEqual(msixPackageVersion, latestGitHubRelease.TagName))
                 {
                     return latestGitHubRelease;
                 }
@@ -35,7 +35,7 @@ public class GitHubHelper
         IReadOnlyList<Release> allGitHubReleases = await releases.GetAll(gitHubRepoOwner, gitHubRepoName);
         foreach (Release gitHubRelease in allGitHubReleases)
         {
-            if (CommonHelper.MsixPackageAndGitHubReleaseVersionsAreEqual(msixPackageVersion, gitHubRelease.TagName))
+            if (VersionComparer.MsixPackageAndGitHubReleaseVersionsAreEqual(msixPackageVersion, gitHubRelease.TagName))
             {
                 return gitHubRelease;
             }

--- a/UploadMicrosoftStoreMsixPackageToGitHubRelease/VersionComparer.cs
+++ b/UploadMicrosoftStoreMsixPackageToGitHubRelease/VersionComparer.cs
@@ -2,7 +2,7 @@ using System.Text.RegularExpressions;
 
 namespace UploadMicrosoftStoreMsixPackageToGitHubRelease;
 
-public static partial class CommonHelper
+public static partial class VersionComparer
 {
     /// <summary>
     /// A regex that matches a version string with 3 digits like "1.2.3".


### PR DESCRIPTION
For example, if the latest Microsoft Store package version is `1.2.3.0`, it will upload MSIX packages to the GitHub release whose tag contains `1.2.3`, like:

- `1.2.3`
- `1.2.3.0`
- `v1.2.3.dev`
- `Version-1.2.3.0-Preview`

Implemented by using a regex `\d+\.\d+\.\d+` to match version in tag.